### PR TITLE
Adding WSSecurity Auth method

### DIFF
--- a/src/soap-constants.ts
+++ b/src/soap-constants.ts
@@ -1,1 +1,3 @@
 export const SOAP_MODULE_OPTIONS = 'SOAP_MODULE_OPTIONS';
+export const BASIC_AUTH = 'basic';
+export const WSSECURITY_AUTH = 'wssecurity';

--- a/src/soap-module-options.type.ts
+++ b/src/soap-module-options.type.ts
@@ -1,20 +1,20 @@
 import { IOptions } from 'soap';
 import { ModuleMetadata, Type } from '@nestjs/common';
+import { BASIC_AUTH, WSSECURITY_AUTH } from './soap-constants';
 
 export { Client, IOptions } from 'soap';
 
-export type BasicAuth = {
-  type?: string
+interface Auth {
+  type: typeof BASIC_AUTH | typeof WSSECURITY_AUTH;
   username: string;
   password: string;
-};
+}
 
-export type WSSecurityType = {
-  type: string
-  username: string;
-  password: string;
-  options?: WSSecurityOptions;
-};
+export interface BasicAuth extends Auth { }
+
+export interface WSSecurityAuth extends Auth {
+  options?: WSSecurityOptions
+}
 
 export type WSSecurityOptions = {
   passwordType?: string;
@@ -28,7 +28,7 @@ export type WSSecurityOptions = {
 export type SoapModuleOptions = {
   uri: string;
   clientName: string;
-  auth?: BasicAuth | WSSecurityType;
+  auth?: BasicAuth | WSSecurityAuth;
   clientOptions?: IOptions;
 };
 

--- a/src/soap-module-options.type.ts
+++ b/src/soap-module-options.type.ts
@@ -13,7 +13,7 @@ export type WSSecurityType = {
   type: string
   username: string;
   password: string;
-  options?: string;
+  options?: WSSecurityOptions;
 };
 
 export type WSSecurityOptions = {

--- a/src/soap-module-options.type.ts
+++ b/src/soap-module-options.type.ts
@@ -4,14 +4,31 @@ import { ModuleMetadata, Type } from '@nestjs/common';
 export { Client, IOptions } from 'soap';
 
 export type BasicAuth = {
+  type?: string
   username: string;
   password: string;
+};
+
+export type WSSecurityType = {
+  type: string
+  username: string;
+  password: string;
+  options?: string;
+};
+
+export type WSSecurityOptions = {
+  passwordType?: string;
+  hasTimeStamp?: boolean;
+  hasTokenCreated?: boolean;
+  hasNonce?: boolean;
+  mustUnderstand?: boolean,
+  actor?: string;
 };
 
 export type SoapModuleOptions = {
   uri: string;
   clientName: string;
-  auth?: BasicAuth;
+  auth?: BasicAuth | WSSecurityType;
   clientOptions?: IOptions;
 };
 

--- a/src/soap.service.spec.ts
+++ b/src/soap.service.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { SoapService } from './soap.service';
 import { mocked } from 'ts-jest/utils';
-import { Client, createClientAsync } from 'soap';
+import { BasicAuthSecurity, Client, createClientAsync, WSSecurity } from 'soap';
 import { MaybeMocked } from 'ts-jest/dist/utils/testing';
 import { SoapModuleOptions } from 'src';
 import { SOAP_MODULE_OPTIONS } from './soap-constants';
@@ -79,6 +79,40 @@ describe('SoapService', () => {
       await service.createAsyncClient();
 
       expect(clientMock.setSecurity).toBeCalled();
+    });
+
+    it('Should use BasicAuthSecurity if auth.type is not defined', async () => {
+      soapCreateClientAsyncMock.mockResolvedValue(clientMock);
+
+      await service.createAsyncClient();
+
+      expect(clientMock.setSecurity).toBeCalledWith(expect.any(BasicAuthSecurity));
+    });
+
+    it('Should use BasicAuthSecurity if auth.type is Basic', async () => {
+      const auth = soapModuleOptionsMock.auth;
+      service.soapModuleOptions.auth.type = 'Basic';
+      
+      soapCreateClientAsyncMock.mockResolvedValue(clientMock);
+
+      await service.createAsyncClient();
+
+      expect(clientMock.setSecurity).toBeCalledWith(expect.any(BasicAuthSecurity));
+      
+      soapModuleOptionsMock.auth = auth;
+    });
+
+    it('Should use WSSecurity if auth.type is WSSecurity', async () => {
+      const auth = soapModuleOptionsMock.auth;
+      service.soapModuleOptions.auth.type = 'WSSecurity';
+      
+      soapCreateClientAsyncMock.mockResolvedValue(clientMock);
+
+      await service.createAsyncClient();
+
+      expect(clientMock.setSecurity).toBeCalledWith(expect.any(WSSecurity));
+      
+      soapModuleOptionsMock.auth = auth;
     });
 
     it('Should return client', async () => {

--- a/src/soap.service.spec.ts
+++ b/src/soap.service.spec.ts
@@ -4,7 +4,7 @@ import { mocked } from 'ts-jest/utils';
 import { BasicAuthSecurity, Client, createClientAsync, WSSecurity } from 'soap';
 import { MaybeMocked } from 'ts-jest/dist/utils/testing';
 import { SoapModuleOptions } from 'src';
-import { SOAP_MODULE_OPTIONS } from './soap-constants';
+import { BASIC_AUTH, SOAP_MODULE_OPTIONS, WSSECURITY_AUTH } from './soap-constants';
 
 const soapModuleOptionsMock = {
   uri: 'some-uri',
@@ -89,9 +89,9 @@ describe('SoapService', () => {
       expect(clientMock.setSecurity).toBeCalledWith(expect.any(BasicAuthSecurity));
     });
 
-    it('Should use BasicAuthSecurity if auth.type is Basic', async () => {
+    it('Should use BasicAuthSecurity if auth.type is BASIC_AUTH', async () => {
       const auth = soapModuleOptionsMock.auth;
-      service.soapModuleOptions.auth.type = 'Basic';
+      service.soapModuleOptions.auth.type = BASIC_AUTH;
       
       soapCreateClientAsyncMock.mockResolvedValue(clientMock);
 
@@ -102,9 +102,9 @@ describe('SoapService', () => {
       soapModuleOptionsMock.auth = auth;
     });
 
-    it('Should use WSSecurity if auth.type is WSSecurity', async () => {
+    it('Should use WSSecurity if auth.type is WSSECURITY_AUTH', async () => {
       const auth = soapModuleOptionsMock.auth;
-      service.soapModuleOptions.auth.type = 'WSSecurity';
+      service.soapModuleOptions.auth.type = WSSECURITY_AUTH;
       
       soapCreateClientAsyncMock.mockResolvedValue(clientMock);
 

--- a/src/soap.service.ts
+++ b/src/soap.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
-import { SoapModuleOptions } from './soap-module-options.type';
+import { SoapModuleOptions, WSSecurityType } from './soap-module-options.type';
 import { SOAP_MODULE_OPTIONS } from './soap-constants';
-import { BasicAuthSecurity, Client, createClientAsync, ISecurity } from 'soap';
+import { BasicAuthSecurity, Client, createClientAsync, ISecurity, WSSecurity } from 'soap';
 
 @Injectable()
 export class SoapService {
@@ -15,12 +15,13 @@ export class SoapService {
 
       if (!options.auth) return client;
 
-      const basicAuth: ISecurity = new BasicAuthSecurity(
-        options.auth.username,
-        options.auth.password,
-      );
+      const {username, password} = options.auth;
 
-      client.setSecurity(basicAuth);
+      const authMethod: ISecurity = options.auth.type === 'WSSecurity'
+        ? new WSSecurity(username, password, (options.auth as WSSecurityType).options)
+        : new BasicAuthSecurity(username, password);
+
+      client.setSecurity(authMethod);
 
       return client;
 

--- a/src/soap.service.ts
+++ b/src/soap.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
-import { SoapModuleOptions, WSSecurityType } from './soap-module-options.type';
-import { SOAP_MODULE_OPTIONS } from './soap-constants';
+import { SoapModuleOptions, WSSecurityAuth } from './soap-module-options.type';
+import { SOAP_MODULE_OPTIONS, WSSECURITY_AUTH } from './soap-constants';
 import { BasicAuthSecurity, Client, createClientAsync, ISecurity, WSSecurity } from 'soap';
 
 @Injectable()
@@ -17,8 +17,8 @@ export class SoapService {
 
       const {username, password} = options.auth;
 
-      const authMethod: ISecurity = options.auth.type === 'WSSecurity'
-        ? new WSSecurity(username, password, (options.auth as WSSecurityType).options)
+      const authMethod: ISecurity = options.auth.type === WSSECURITY_AUTH
+        ? new WSSecurity(username, password, (options.auth as WSSecurityAuth).options)
         : new BasicAuthSecurity(username, password);
 
       client.setSecurity(authMethod);


### PR DESCRIPTION
## Intro
Moving forward with this #20, here goes the PR to iterate the proposal :).  

## What changed
- Add new types (WSSecurityOptions, WSSecurityType)
- Allow new auth type to SoapModuleOptions
- Change how to auth method is create and setting to the client.
- Add some test to cover new code.

## Test
```javascript
-----------------------------|---------|----------|---------|---------|-------------------
File                         | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-----------------------------|---------|----------|---------|---------|-------------------
All files                    |   97.01 |      100 |      85 |    96.3 |                   
 soap-constants.ts           |     100 |      100 |     100 |     100 |                   
 soap-module-options.type.ts |     100 |      100 |       0 |     100 |                   
 soap-providers.ts           |   92.86 |      100 |   81.82 |   90.48 | 45-46             
 soap.module.ts              |     100 |      100 |     100 |     100 |                   
 soap.service.ts             |     100 |      100 |     100 |     100 |                   
-----------------------------|---------|----------|---------|---------|-------------------
Test Suites: 3 passed, 3 total
Tests:       19 passed, 19 total
Snapshots:   0 total
Time:        12.062 s
Ran all test suites.
```