### PR TITLE
Adds NTLM auth support

### DIFF
--- a/src/soap-constants.ts
+++ b/src/soap-constants.ts
@@ -1,3 +1,4 @@
 export const SOAP_MODULE_OPTIONS = 'SOAP_MODULE_OPTIONS';
 export const BASIC_AUTH = 'basic';
 export const WSSECURITY_AUTH = 'wssecurity';
+export const NTLM_AUTH = 'ntlm'

--- a/src/soap-module-options.type.ts
+++ b/src/soap-module-options.type.ts
@@ -1,11 +1,11 @@
 import { IOptions } from 'soap';
 import { ModuleMetadata, Scope, Type } from '@nestjs/common/interfaces';
-import { BASIC_AUTH, WSSECURITY_AUTH } from './soap-constants';
+import { BASIC_AUTH, NTLM_AUTH, WSSECURITY_AUTH } from './soap-constants';
 
 export { Client, IOptions } from 'soap';
 
 interface Auth {
-  type: typeof BASIC_AUTH | typeof WSSECURITY_AUTH;
+  type: typeof BASIC_AUTH | typeof WSSECURITY_AUTH | typeof NTLM_AUTH;
   username: string;
   password: string;
 }
@@ -21,14 +21,25 @@ export type WSSecurityOptions = {
   hasTimeStamp?: boolean;
   hasTokenCreated?: boolean;
   hasNonce?: boolean;
-  mustUnderstand?: boolean,
+  mustUnderstand?: boolean;
   actor?: string;
 };
+
+export interface NTLMSecurityAuth extends Auth {
+  options?: NTLMSecurityOptions
+}
+
+export type NTLMSecurityOptions = {
+  domain?: string;
+  workstation?: string;
+}
+
+export type AuthType = BasicAuth | WSSecurityAuth | NTLMSecurityAuth;
 
 export type SoapModuleOptions = {
   uri: string;
   clientName: string;
-  auth?: BasicAuth | WSSecurityAuth;
+  auth?: AuthType;
   clientOptions?: IOptions;
 };
 

--- a/src/soap.service.spec.ts
+++ b/src/soap.service.spec.ts
@@ -1,10 +1,11 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { SoapService } from './soap.service';
 import { mocked } from 'ts-jest/utils';
-import { BasicAuthSecurity, Client, createClientAsync, WSSecurity } from 'soap';
+import { BasicAuthSecurity, Client, createClientAsync, NTLMSecurity, WSSecurity } from 'soap';
 import { MaybeMocked } from 'ts-jest/dist/utils/testing';
-import { SoapModuleOptions } from 'src';
-import { BASIC_AUTH, SOAP_MODULE_OPTIONS, WSSECURITY_AUTH } from './soap-constants';
+
+import { SoapModuleOptions } from './soap-module-options.type';
+import { BASIC_AUTH, SOAP_MODULE_OPTIONS, WSSECURITY_AUTH, NTLM_AUTH } from './soap-constants';
+import { SoapService } from './soap.service';
 
 const soapModuleOptionsMock = {
   uri: 'some-uri',
@@ -111,6 +112,19 @@ describe('SoapService', () => {
       await service.createAsyncClient();
 
       expect(clientMock.setSecurity).toBeCalledWith(expect.any(WSSecurity));
+      
+      soapModuleOptionsMock.auth = auth;
+    });
+
+    it('Should use NTLMSecurity if auth.type is NTLM_AUTH', async () => {
+      const auth = soapModuleOptionsMock.auth;
+      service.soapModuleOptions.auth.type = NTLM_AUTH;
+      
+      soapCreateClientAsyncMock.mockResolvedValue(clientMock);
+
+      await service.createAsyncClient();
+
+      expect(clientMock.setSecurity).toBeCalledWith(expect.any(NTLMSecurity));
       
       soapModuleOptionsMock.auth = auth;
     });

--- a/src/soap.service.ts
+++ b/src/soap.service.ts
@@ -1,7 +1,15 @@
+import { 
+  createClientAsync,
+  Client,
+  BasicAuthSecurity,
+  ISecurity,
+  WSSecurity,
+  NTLMSecurity 
+} from 'soap';
+
 import { Inject, Injectable, Logger } from '@nestjs/common';
-import { SoapModuleOptions, WSSecurityAuth } from './soap-module-options.type';
-import { SOAP_MODULE_OPTIONS, WSSECURITY_AUTH } from './soap-constants';
-import { BasicAuthSecurity, Client, createClientAsync, ISecurity, WSSecurity } from 'soap';
+import { AuthType, NTLMSecurityAuth, SoapModuleOptions, WSSecurityAuth } from './soap-module-options.type';
+import { NTLM_AUTH, SOAP_MODULE_OPTIONS, WSSECURITY_AUTH } from './soap-constants';
 
 @Injectable()
 export class SoapService {
@@ -15,11 +23,7 @@ export class SoapService {
 
       if (!options.auth) return client;
 
-      const {username, password} = options.auth;
-
-      const authMethod: ISecurity = options.auth.type === WSSECURITY_AUTH
-        ? new WSSecurity(username, password, (options.auth as WSSecurityAuth).options)
-        : new BasicAuthSecurity(username, password);
+      const authMethod = this.getAuthMethod(options.auth);
 
       client.setSecurity(authMethod);
 
@@ -33,6 +37,26 @@ export class SoapService {
       );
 
       return null;
+    }
+  }
+
+  private getAuthMethod(authOptions: AuthType): ISecurity {
+    const { username, password, type } = authOptions;
+
+    switch (type) {
+      case WSSECURITY_AUTH:
+        const WSSOptions = (authOptions as WSSecurityAuth).options;
+        return new WSSecurity(username, password, WSSOptions);
+      case NTLM_AUTH:
+        const NTLMOptions = (authOptions as NTLMSecurityAuth).options;
+        const loginData = {
+          username,
+          password,
+          ...NTLMOptions
+        };
+        return new NTLMSecurity(loginData);
+      default:
+        return new BasicAuthSecurity(username, password);
     }
   }
 }


### PR DESCRIPTION
Added NTLM auth support.
Example use:
```typescript
...
useFactory: async (
  configService: ConfigService,
): Promise<SoapModuleOptions> => ({
  uri: configService.get<string>('soap.uri'),
  auth: {
    type: 'ntlm',
    username: configService.get<string>('soap.username'),
    password: configService.get<string>('soap.password'),
    options: {
      domain: 'domain',
      workspace: 'workspace'
    }
  },
}), 
`

